### PR TITLE
Make importing material optional

### DIFF
--- a/Source/VOX4UEditor/Private/VoxImportOption.cpp
+++ b/Source/VOX4UEditor/Private/VoxImportOption.cpp
@@ -10,6 +10,7 @@ UVoxImportOption::UVoxImportOption()
 	: VoxImportType(EVoxImportType::StaticMesh)
 	, bImportXForward(true)
 	, bImportXYCenter(true)
+	, bImportMaterial(true)
 	, Scale(10.f)
 {
 	BuildSettings.BuildScale3D = FVector(Scale);

--- a/Source/VOX4UEditor/Private/VoxImportOption.h
+++ b/Source/VOX4UEditor/Private/VoxImportOption.h
@@ -37,6 +37,9 @@ public:
 	uint32 bImportXYCenter : 1;
 
 	UPROPERTY(EditAnywhere, Category = Generic)
+	uint32 bImportMaterial : 1;
+	
+	UPROPERTY(EditAnywhere, Category = Generic)
 	float Scale;
 
 public:

--- a/Source/VOX4UEditor/Private/VoxelFactory.cpp
+++ b/Source/VOX4UEditor/Private/VoxelFactory.cpp
@@ -191,8 +191,13 @@ UStaticMesh* UVoxelFactory::CreateStaticMesh(UObject* InParent, FName InName, EO
 
 	FRawMesh RawMesh;
 	Vox->CreateOptimizedRawMesh(RawMesh, ImportOption);
-	UMaterialInterface* Material = CreateMaterial(InParent, InName, Flags, Vox);
-	StaticMesh->StaticMaterials.Add(FStaticMaterial(Material));
+
+	if ( ImportOption->bImportMaterial )
+	{
+		UMaterialInterface* Material = CreateMaterial(InParent, InName, Flags, Vox);
+		StaticMesh->StaticMaterials.Add(FStaticMaterial(Material));
+	}
+	
 	BuildStaticMesh(StaticMesh, RawMesh);
 	StaticMesh->AssetImportData->Update(Vox->Filename);
 	return StaticMesh;


### PR DESCRIPTION
**My Use Case:** I have several vox models that share the same color palette and material properties and I do not need and do not want the importer to generate the materials and textures per model.

This pull request adds a new import option called "Import Material". It is turned on by default and does not change default import behaviour.

If toggled off, the import will not create the material and texture for the vox object.